### PR TITLE
feat: support the all flag to show hidden files

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 
 #[derive(Parser, Debug)]
-#[command(version, about = "List files and directories in a directory.")]
+#[command(version, about = "List files and directories within a directory.")]
 pub(crate) struct Args {
     /// Name of the directory
     #[clap(default_value = ".")]
@@ -10,4 +10,8 @@ pub(crate) struct Args {
     /// Show file permissions
     #[clap(short, long, default_value = "false")]
     pub(crate) permissions: bool,
+
+    /// Show all items
+    #[clap(short, long, default_value = "false")]
+    pub(crate) all: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use derive_builder::Builder;
+use std::ffi::OsString;
 use std::fs;
 
 #[derive(Builder, Debug, PartialEq)]
@@ -6,8 +7,11 @@ pub struct DirectoryItem {
     /// Name of the item within the directory
     pub name: String,
 
-    // Type of the item within the directory
+    /// Type of the item within the directory
     pub is_dir: bool,
+
+    /// Is item hidden within the directory
+    pub is_hidden: bool,
 }
 
 /// Find items within a directory and return back a vector with the directory items.
@@ -20,6 +24,7 @@ pub fn find_directory_items(directory: &std::path::Path) -> Vec<DirectoryItem> {
         let dir_item = DirectoryItemBuilder::default()
             .name(entry.file_name().to_str().unwrap().to_owned())
             .is_dir(entry.file_type().unwrap().to_owned().is_dir())
+            .is_hidden(is_file_hidden(entry.file_name()))
             .build();
 
         items.push(dir_item.unwrap())
@@ -31,6 +36,11 @@ pub fn find_directory_items(directory: &std::path::Path) -> Vec<DirectoryItem> {
 /// Convert a string to a path object
 pub fn path_to_str(path: &String) -> &std::path::Path {
     std::path::Path::new(path)
+}
+
+/// Check if a file or directory is hidden
+fn is_file_hidden(file_name: OsString) -> bool {
+    file_name.to_str().unwrap().starts_with(".")
 }
 
 #[cfg(test)]
@@ -57,12 +67,34 @@ mod tests {
             DirectoryItem {
                 name: "file.txt".to_string(),
                 is_dir: false,
+                is_hidden: false,
             },
             DirectoryItem {
                 name: "subdir".to_string(),
                 is_dir: true,
+                is_hidden: false,
             },
         ];
+
+        assert_eq!(items, expected);
+    }
+
+    #[test]
+    fn test_find_directory_items_with_hidden_file() {
+        let temp = TempDir::new().unwrap();
+        temp.child(".file.txt").touch().unwrap();
+
+        let mut items = find_directory_items(temp.path());
+
+        items.sort_by(|a, b| a.name.cmp(&b.name));
+
+        assert_eq!(items.len(), 1);
+
+        let expected: Vec<DirectoryItem> = vec![DirectoryItem {
+            name: ".file.txt".to_string(),
+            is_dir: false,
+            is_hidden: true,
+        }];
 
         assert_eq!(items, expected);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,19 @@ fn main() {
     let path: &std::path::Path = path_to_str(&args.directory);
     let dir_items: Vec<DirectoryItem> = find_directory_items(path);
 
-    let colourised_output: String = output(&dir_items);
+    let filter = if args.all { show_all } else { hide_hidden };
+
+    let colourised_output: String = output(&dir_items, filter);
+
     println!("{}", colourised_output);
+}
+
+/// Include all items in output including hidden files
+fn show_all(_: &DirectoryItem) -> bool {
+    true
+}
+
+/// Remove hidden files from the output
+fn hide_hidden(item: &DirectoryItem) -> bool {
+    !item.is_hidden
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -67,6 +67,6 @@ mod tests {
 
         let expected = "";
 
-        assert_eq!(output(&items, |item| item.is_hidden), expected);
+        assert_eq!(output(&items, |item| !item.is_hidden), expected);
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -6,22 +6,30 @@ const STYLE_RESET: &str = "\x1b[0m";
 const COLOUR_RESET: &str = "\x1b[39m";
 
 /// Output colourised output based on file type  
-pub fn output(items: &Vec<DirectoryItem>) -> String {
+pub fn output<F>(items: &[DirectoryItem], filter: F) -> String
+where
+    F: Fn(&DirectoryItem) -> bool,
+{
     let mut output = String::new();
-    items.into_iter().for_each(|item| {
+    items.iter().filter(|item| filter(item)).for_each(|item| {
         if item.is_dir {
-            let dir_output: String = format!(
-                "{}{}{}{}{}",
-                STYLE_BOLD, COLOUR_PINK, &item.name, STYLE_RESET, COLOUR_RESET
-            );
-            output.push_str(&dir_output);
-            output.push_str(" ");
+            create_dir_output(&mut output, &item);
         } else {
             output.push_str(&item.name);
             output.push_str(" ");
         }
     });
     output
+}
+
+/// Create default directory output
+fn create_dir_output(output: &mut String, item: &&DirectoryItem) {
+    let dir_output: String = format!(
+        "{}{}{}{}{}",
+        STYLE_BOLD, COLOUR_PINK, &item.name, STYLE_RESET, COLOUR_RESET
+    );
+    output.push_str(&dir_output);
+    output.push_str(" ");
 }
 
 #[cfg(test)]
@@ -35,15 +43,30 @@ mod tests {
             DirectoryItem {
                 name: "testfile.txt".to_string(),
                 is_dir: false,
+                is_hidden: false,
             },
             DirectoryItem {
                 name: "subdir".to_string(),
                 is_dir: true,
+                is_hidden: false,
             },
         ];
 
         let expected = "testfile.txt \u{1b}[1m\u{1b}[95msubdir\u{1b}[0m\u{1b}[39m ";
 
-        assert_eq!(output(&items), expected);
+        assert_eq!(output(&items, |_| true), expected);
+    }
+
+    #[test]
+    fn test_output_without_hidden_items() {
+        let items = vec![DirectoryItem {
+            name: ".DS_Store".to_string(),
+            is_dir: false,
+            is_hidden: true,
+        }];
+
+        let expected = "";
+
+        assert_eq!(output(&items, |item| item.is_hidden), expected);
     }
 }


### PR DESCRIPTION
## Description

Add support for a flag to show all items within a directory including a dotfile. 

[//]: # (Describe the changes in this pull request)

## Changes in this pull request

- Add support for all flag 

[//]: # (List changes in this pull request )