### PR TITLE
chore: rename project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,15 +340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
-name = "ld"
-version = "0.1.0"
-dependencies = [
- "assert_fs",
- "clap",
- "derive_builder",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +356,15 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lx"
+version = "0.1.0"
+dependencies = [
+ "assert_fs",
+ "clap",
+ "derive_builder",
+]
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ld"
+name = "lx"
 version = "0.1.0"
 edition = "2024"
 description = "List files and directories in a directory"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ld 
+# lx
 
 An `ls` clone written in Rust, mostly done so that I can learn Rust. 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod output;
 
 use args::Args;
 use clap::Parser;
-use ld::{DirectoryItem, find_directory_items, path_to_str};
+use lx::{DirectoryItem, find_directory_items, path_to_str};
 use output::output;
 
 fn main() {

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,4 +1,4 @@
-use ld::DirectoryItem;
+use lx::DirectoryItem;
 
 const STYLE_BOLD: &str = "\x1b[1m";
 const COLOUR_PINK: &str = "\x1b[95m";
@@ -35,7 +35,7 @@ fn create_dir_output(output: &mut String, item: &&DirectoryItem) {
 #[cfg(test)]
 mod tests {
     use crate::output::output;
-    use ld::DirectoryItem;
+    use lx::DirectoryItem;
 
     #[test]
     fn test_output() {


### PR DESCRIPTION
## Description

Rename project in `cargo.toml` to `lx` instead of `ld`

[//]: # (Describe the changes in this pull request)

## Changes in this pull request

- Rename project and other imports 

[//]: # (List changes in this pull request )